### PR TITLE
한글약력 추가, 작품목록 오름차순으로 변경, 메인메뉴의 서브메뉴 중복 문제 해결

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,24 +1,29 @@
 items:
   - title: artwork
-    url: /artwork/2019-2020
+    url: /artwork/2020-2019
     subitems:
-      - title: 2019-2020
-        url: /artwork/2019-2020
+      - title: 2020-2019
+        url: /artwork/2020-2019
       - title: 2018
         url: /artwork/2018
       - title: 2017
         url: /artwork/2017
-      - title: 2015-2016
-        url: /artwork/2015-2016
-      - title: 2012-2014
-        url: /artwork/2012-2014
-      - title: 2010-2011
-        url: /artwork/2010-2011
-      - title: 2007-2009
-        url: /artwork/2007-2009
+      - title: 2016-2015
+        url: /artwork/2016-2015
+      - title: 2014-2012
+        url: /artwork/2014-2012
+      - title: 2011-2010
+        url: /artwork/2011-2010
+      - title: 2009-2007
+        url: /artwork/2009-2007
   - title: text
     url: /texts
   - title: cv
     url: /cv
+    subitems:
+      - title: en
+        url: /cv
+      - title: ko
+        url: /cv-ko
   - title: contact
     url: /contact

--- a/_layouts/cv-ko.html
+++ b/_layouts/cv-ko.html
@@ -1,0 +1,28 @@
+---
+layout: page
+---
+
+<article class="about-wrapper">
+  <section class="about-info">
+    {% if site.data.author.description %}
+      <p>{{ site.data.author.description }}</p>
+    {% endif %}
+    {% if site.data.author.email %}
+      <p><a href="mailto:{{ site.data.author.email }}">{{ site.data.author.email }}</a></p>
+    {% endif %}
+    {{ content }}
+  </section>
+  {% if site.data.author.exhibitions %}
+    <section class="about-exhibitions">
+      <h2>Exhibitions</h2>
+      {% for exgroup in site.data.author.exhibitions %}
+        <h3>{{ exgroup.title }}</h3>
+        <ul>
+          {% for exitem in exgroup.list %}
+            <li>{{ exitem }}</li>
+          {% endfor %}
+        </ul>
+      {% endfor %}
+    </section>
+  {% endif %}
+</article>

--- a/_posts/artworks/2007/2007-01-01-heilige-allegorie.md
+++ b/_posts/artworks/2007/2007-01-01-heilige-allegorie.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2007-2009"
+categories: "2009-2007"
 author: Jihoon Ha
 title: heilige allegorie
 caption: heilige allegorie_oil on canvas_70×70㎝_2007

--- a/_posts/artworks/2008/2008-01-01-5-villages.md
+++ b/_posts/artworks/2008/2008-01-01-5-villages.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2007-2009"
+categories: "2009-2007"
 author: Jihoon Ha
 title: 5 villages
 caption: 5 villages_oil on canvas_110×170㎝_2008

--- a/_posts/artworks/2008/2008-01-01-castle.md
+++ b/_posts/artworks/2008/2008-01-01-castle.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2007-2009"
+categories: "2009-2007"
 author: Jihoon Ha
 title: castle
 caption: castle_oil on canvas_70×70㎝_2008

--- a/_posts/artworks/2008/2008-01-01-individual-landscape-statue-2.md
+++ b/_posts/artworks/2008/2008-01-01-individual-landscape-statue-2.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2007-2009"
+categories: "2009-2007"
 author: Jihoon Ha
 title: "statue #2"
 caption: "statue #2_oil on canvas_70×70㎝_2008"

--- a/_posts/artworks/2008/2008-01-01-individual-landscape-statue-3.md
+++ b/_posts/artworks/2008/2008-01-01-individual-landscape-statue-3.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2007-2009"
+categories: "2009-2007"
 author: Jihoon Ha
 title: "statue #3"
 caption: "statue #3_oil on canvas_70×70㎝_2008"

--- a/_posts/artworks/2008/2008-01-01-individual-landscape-statue-4.md
+++ b/_posts/artworks/2008/2008-01-01-individual-landscape-statue-4.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2007-2009"
+categories: "2009-2007"
 author: Jihoon Ha
 title: "statue #4"
 caption: "statue #4_oil on canvas_70×70㎝_2008"

--- a/_posts/artworks/2008/2008-01-01-individual-landscape-statue.md
+++ b/_posts/artworks/2008/2008-01-01-individual-landscape-statue.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2007-2009"
+categories: "2009-2007"
 author: Jihoon Ha
 title: statue
 caption: statue_acrylic,oil on canvas_120×105㎝_2008

--- a/_posts/artworks/2008/2008-01-01-island.md
+++ b/_posts/artworks/2008/2008-01-01-island.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2007-2009"
+categories: "2009-2007"
 author: Jihoon Ha
 title: island
 caption: island_mixed media on transformed canvas_70×47×67㎝_2008

--- a/_posts/artworks/2008/2008-01-01-promenade.md
+++ b/_posts/artworks/2008/2008-01-01-promenade.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2007-2009"
+categories: "2009-2007"
 author: Jihoon Ha
 title: promenade
 caption: promenade_oil on canvas_130×160㎝_2008

--- a/_posts/artworks/2008/2008-01-01-unknown-paradise.md
+++ b/_posts/artworks/2008/2008-01-01-unknown-paradise.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2007-2009"
+categories: "2009-2007"
 author: Jihoon Ha
 title: unknown paradise
 caption: unknown paradise_oil on canvas_135×150㎝_2008

--- a/_posts/artworks/2009/2009-01-01-botarnische-garten.md
+++ b/_posts/artworks/2009/2009-01-01-botarnische-garten.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2007-2009"
+categories: "2009-2007"
 author: Jihoon Ha
 title: botarnische garten
 caption: botarnische garten_acrylic,oil on canvas_180×220㎝_2009

--- a/_posts/artworks/2009/2009-01-01-fortress-1.md
+++ b/_posts/artworks/2009/2009-01-01-fortress-1.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2007-2009"
+categories: "2009-2007"
 author: Jihoon Ha
 title: "fortress #1"
 caption: "fortress #1_oil on canvas_165×145㎝_2009"

--- a/_posts/artworks/2009/2009-01-01-fortress-2.md
+++ b/_posts/artworks/2009/2009-01-01-fortress-2.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2007-2009"
+categories: "2009-2007"
 author: Jihoon Ha
 title: "fortress #2"
 caption: "fortress #2_oil on canvas_155×175㎝_2009"

--- a/_posts/artworks/2009/2009-01-01-individual-landscape-4.md
+++ b/_posts/artworks/2009/2009-01-01-individual-landscape-4.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2007-2009"
+categories: "2009-2007"
 author: Jihoon Ha
 title: "individual landscape #4"
 caption: "individual landscape #4_oil on paper_25×25㎝_2009"

--- a/_posts/artworks/2009/2009-01-01-individual-landscape.md
+++ b/_posts/artworks/2009/2009-01-01-individual-landscape.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2007-2009"
+categories: "2009-2007"
 author: Jihoon Ha
 title: individual landscape
 caption: individual landscape_acrylic,oil on canvas_70×70㎝_2009

--- a/_posts/artworks/2009/2009-01-01-individual-landscape2.md
+++ b/_posts/artworks/2009/2009-01-01-individual-landscape2.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2007-2009"
+categories: "2009-2007"
 author: Jihoon Ha
 title: individual landscape
 caption: individual landscape_oil on paper_25×25㎝_2009

--- a/_posts/artworks/2009/2009-01-01-individual-landscape3.md
+++ b/_posts/artworks/2009/2009-01-01-individual-landscape3.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2007-2009"
+categories: "2009-2007"
 author: Jihoon Ha
 title: individual landscape
 caption: individual landscape_oil on paper_26×40㎝_2009

--- a/_posts/artworks/2009/2009-01-01-individual-landscape4.md
+++ b/_posts/artworks/2009/2009-01-01-individual-landscape4.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2007-2009"
+categories: "2009-2007"
 author: Jihoon Ha
 title: individual landscape
 caption: individual landscape_acrylic,oil on canvas_70×70㎝_2009

--- a/_posts/artworks/2009/2009-01-01-jeju.md
+++ b/_posts/artworks/2009/2009-01-01-jeju.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2007-2009"
+categories: "2009-2007"
 author: Jihoon Ha
 title: jeju
 caption: jeju_oil on canvas_70×70㎝_2009

--- a/_posts/artworks/2009/2009-01-01-landscape-1.md
+++ b/_posts/artworks/2009/2009-01-01-landscape-1.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2007-2009"
+categories: "2009-2007"
 author: Jihoon Ha
 title: "풍경-흔적들 #1"
 caption: "풍경-흔적들 #1_oil on paper_25×25㎝_2009"

--- a/_posts/artworks/2009/2009-01-01-landscape-10.md
+++ b/_posts/artworks/2009/2009-01-01-landscape-10.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2007-2009"
+categories: "2009-2007"
 author: Jihoon Ha
 title: "풍경-흔적들 #10"
 caption: "풍경-흔적들 #10_oil on paper_25×25㎝_2009"

--- a/_posts/artworks/2009/2009-01-01-landscape-2.md
+++ b/_posts/artworks/2009/2009-01-01-landscape-2.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2007-2009"
+categories: "2009-2007"
 author: Jihoon Ha
 title: "풍경-흔적들 #2"
 caption: "풍경-흔적들 #2_oil on paper_25×25㎝_2009"

--- a/_posts/artworks/2009/2009-01-01-landscape-3.md
+++ b/_posts/artworks/2009/2009-01-01-landscape-3.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2007-2009"
+categories: "2009-2007"
 author: Jihoon Ha
 title: "풍경-흔적들 #3"
 caption: "풍경-흔적들 #3_oil on paper_25×25㎝_2009"

--- a/_posts/artworks/2009/2009-01-01-landscape-7.md
+++ b/_posts/artworks/2009/2009-01-01-landscape-7.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2007-2009"
+categories: "2009-2007"
 author: Jihoon Ha
 title: "풍경-흔적들 #7"
 caption: "풍경-흔적들 #7_oil on paper_25×25㎝_2009"

--- a/_posts/artworks/2009/2009-01-01-landscape-8.md
+++ b/_posts/artworks/2009/2009-01-01-landscape-8.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2007-2009"
+categories: "2009-2007"
 author: Jihoon Ha
 title: "풍경-흔적들 #8"
 caption: "풍경-흔적들 #8_oil on paper_25×25㎝_2009"

--- a/_posts/artworks/2009/2009-01-01-landscape-9.md
+++ b/_posts/artworks/2009/2009-01-01-landscape-9.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2007-2009"
+categories: "2009-2007"
 author: Jihoon Ha
 title: "풍경-흔적들 #9"
 caption: "풍경-흔적들 #9_oil on paper_25×25㎝_2009"

--- a/_posts/artworks/2009/2009-01-01-landscape-pyramid.md
+++ b/_posts/artworks/2009/2009-01-01-landscape-pyramid.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2007-2009"
+categories: "2009-2007"
 author: Jihoon Ha
 title: landscape-pyramid
 caption: landscape-pyramid_acrylic,oil on canvas_150×150㎝_2009

--- a/_posts/artworks/2009/2009-01-01-landscapestatue-acrylic.md
+++ b/_posts/artworks/2009/2009-01-01-landscapestatue-acrylic.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2007-2009"
+categories: "2009-2007"
 author: Jihoon Ha
 title: landscape-statue
 caption: landscape-statue_acrylic,_oil on canvas_165×145㎝_2009

--- a/_posts/artworks/2009/2009-01-01-ot.md
+++ b/_posts/artworks/2009/2009-01-01-ot.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2007-2009"
+categories: "2009-2007"
 author: Jihoon Ha
 title: o.T.
 caption: o.T._acrylic,oil on canvas_150×150㎝_2009

--- a/_posts/artworks/2010/2010-01-01-fortress-3.md
+++ b/_posts/artworks/2010/2010-01-01-fortress-3.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2010-2011"
+categories: "2011-2010"
 author: Jihoon Ha
 title: "fortress #3"
 caption: "fortress #3_oil on canvas_150×150㎝_2010"

--- a/_posts/artworks/2010/2010-01-01-fortress-5.md
+++ b/_posts/artworks/2010/2010-01-01-fortress-5.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2010-2011"
+categories: "2011-2010"
 author: Jihoon Ha
 title: "fortress #5"
 caption: "fortress #5_oil on canvas_130×160㎝_2010"

--- a/_posts/artworks/2010/2010-01-01-green-edge.md
+++ b/_posts/artworks/2010/2010-01-01-green-edge.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2010-2011"
+categories: "2011-2010"
 author: Jihoon Ha
 title: green edge
 caption: green edge_oil on canvas_60×51㎝_2010

--- a/_posts/artworks/2010/2010-01-01-individual-landscape1.md
+++ b/_posts/artworks/2010/2010-01-01-individual-landscape1.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2010-2011"
+categories: "2011-2010"
 author: Jihoon Ha
 title: individual landscape
 caption: individual landscape_oil on paper_25×25㎝_2010

--- a/_posts/artworks/2010/2010-01-01-individual-landscape2.md
+++ b/_posts/artworks/2010/2010-01-01-individual-landscape2.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2010-2011"
+categories: "2011-2010"
 author: Jihoon Ha
 title: individual landscape
 caption: individual landscape_oil on canvas_51×60㎝_2010

--- a/_posts/artworks/2010/2010-01-01-individual-landscape3.md
+++ b/_posts/artworks/2010/2010-01-01-individual-landscape3.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2010-2011"
+categories: "2011-2010"
 author: Jihoon Ha
 title: individual landscape
 caption: individual landscape_oil on canvas_70×70㎝_2010

--- a/_posts/artworks/2010/2010-01-01-individual-landscape4.md
+++ b/_posts/artworks/2010/2010-01-01-individual-landscape4.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2010-2011"
+categories: "2011-2010"
 author: Jihoon Ha
 title: individual landscape
 caption: individual landscape_oil on canvas_70×70㎝_2010

--- a/_posts/artworks/2010/2010-01-01-individual-landscape5.md
+++ b/_posts/artworks/2010/2010-01-01-individual-landscape5.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2010-2011"
+categories: "2011-2010"
 author: Jihoon Ha
 title: individual landscape
 caption: individual landscape_oil on canvas_90×70㎝_2010

--- a/_posts/artworks/2010/2010-01-01-individual-landscape6.md
+++ b/_posts/artworks/2010/2010-01-01-individual-landscape6.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2010-2011"
+categories: "2011-2010"
 author: Jihoon Ha
 title: 11-individual landscape
 caption: 11-individual landscape_oil on canvas_90×70㎝_2010

--- a/_posts/artworks/2010/2010-01-01-individual-landscape7.md
+++ b/_posts/artworks/2010/2010-01-01-individual-landscape7.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2010-2011"
+categories: "2011-2010"
 author: Jihoon Ha
 title: individual landscape
 caption: individual landscape_acrylic,oil on canvas_150×150㎝_2010

--- a/_posts/artworks/2011/2011-01-01-fortress-6.md
+++ b/_posts/artworks/2011/2011-01-01-fortress-6.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2010-2011"
+categories: "2011-2010"
 author: Jihoon Ha
 title: "fortress #6"
 caption: "fortress #6_oil on canvas_112×290㎝_2011"

--- a/_posts/artworks/2011/2011-01-01-fortress-7.md
+++ b/_posts/artworks/2011/2011-01-01-fortress-7.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2010-2011"
+categories: "2011-2010"
 author: Jihoon Ha
 title: "fortress #7"
 caption: "fortress #7_oil on canvas_105×140㎝_2011"

--- a/_posts/artworks/2011/2011-01-01-individual-landscape-1.md
+++ b/_posts/artworks/2011/2011-01-01-individual-landscape-1.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2010-2011"
+categories: "2011-2010"
 author: Jihoon Ha
 title: "individual landscape #1"
 caption: "individual landscape #1_oil on paper_25×25㎝_2011"

--- a/_posts/artworks/2011/2011-01-01-individual-landscape-1b.md
+++ b/_posts/artworks/2011/2011-01-01-individual-landscape-1b.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2010-2011"
+categories: "2011-2010"
 author: Jihoon Ha
 title: "individual landscape #1"
 caption: "individual landscape #1_oil on paper_25×25㎝_2011"

--- a/_posts/artworks/2011/2011-01-01-individual-landscape-2.md
+++ b/_posts/artworks/2011/2011-01-01-individual-landscape-2.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2010-2011"
+categories: "2011-2010"
 author: Jihoon Ha
 title: "individual landscape #2"
 caption: "individual landscape #2_oil on canvas_32×32㎝_2011"

--- a/_posts/artworks/2011/2011-01-01-individual-landscape-3.md
+++ b/_posts/artworks/2011/2011-01-01-individual-landscape-3.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2010-2011"
+categories: "2011-2010"
 author: Jihoon Ha
 title: "individual landscape #3"
 caption: "individual landscape #3_oil on canvas_32×32㎝_2011"

--- a/_posts/artworks/2011/2011-01-01-individual-landscape-4.md
+++ b/_posts/artworks/2011/2011-01-01-individual-landscape-4.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2010-2011"
+categories: "2011-2010"
 author: Jihoon Ha
 title: "individual landscape #4"
 caption: "individual landscape #4_oil on canvas_32×40㎝_2011"

--- a/_posts/artworks/2011/2011-01-01-individual-landscape-6.md
+++ b/_posts/artworks/2011/2011-01-01-individual-landscape-6.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2010-2011"
+categories: "2011-2010"
 author: Jihoon Ha
 title: "individual landscape #6"
 caption: "individual landscape #6_oil on paper_25×25㎝_2011"

--- a/_posts/artworks/2011/2011-01-01-individual-landscape-forest.md
+++ b/_posts/artworks/2011/2011-01-01-individual-landscape-forest.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2010-2011"
+categories: "2011-2010"
 author: Jihoon Ha
 title: individual landscape-forest
 caption: individual landscape-forest_oil on canvas_91×117㎝_2011

--- a/_posts/artworks/2011/2011-01-01-individual-landscape1.md
+++ b/_posts/artworks/2011/2011-01-01-individual-landscape1.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2010-2011"
+categories: "2011-2010"
 author: Jihoon Ha
 title: individual landscape
 caption: individual landscape_oil on paper_25×25㎝_2011

--- a/_posts/artworks/2011/2011-01-01-individual-landscape2.md
+++ b/_posts/artworks/2011/2011-01-01-individual-landscape2.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2010-2011"
+categories: "2011-2010"
 author: Jihoon Ha
 title: individual landscape
 caption: individual landscape_oil on paper_25×25㎝_2011

--- a/_posts/artworks/2011/2011-01-01-individual-landscape3.md
+++ b/_posts/artworks/2011/2011-01-01-individual-landscape3.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2010-2011"
+categories: "2011-2010"
 author: Jihoon Ha
 title: individual landscape
 caption: individual landscape_oil on canvas_40×32㎝_2011

--- a/_posts/artworks/2011/2011-01-01-individual-landscape4.md
+++ b/_posts/artworks/2011/2011-01-01-individual-landscape4.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2010-2011"
+categories: "2011-2010"
 author: Jihoon Ha
 title: individual landscape
 caption: individual landscape_oil on canvas_each 61×41㎝_2011

--- a/_posts/artworks/2011/2011-01-01-individual-landscape5.md
+++ b/_posts/artworks/2011/2011-01-01-individual-landscape5.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2010-2011"
+categories: "2011-2010"
 author: Jihoon Ha
 title: individual landscape
 caption: individual landscape_oil on canvas_90×70㎝_2011

--- a/_posts/artworks/2011/2011-01-01-individual-landscape6.md
+++ b/_posts/artworks/2011/2011-01-01-individual-landscape6.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2010-2011"
+categories: "2011-2010"
 author: Jihoon Ha
 title: individual landscape
 caption: individual landscape_oil on canvas_115×150㎝_2011

--- a/_posts/artworks/2011/2011-01-01-individual-landscape7.md
+++ b/_posts/artworks/2011/2011-01-01-individual-landscape7.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2010-2011"
+categories: "2011-2010"
 author: Jihoon Ha
 title: individual landscape
 caption: individual landscape_oil on canvas_145×165㎝_2011

--- a/_posts/artworks/2012/2012-01-01-2-trees.md
+++ b/_posts/artworks/2012/2012-01-01-2-trees.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2012-2014"
+categories: "2014-2012"
 author: Jihoon Ha
 title: 2 trees
 caption: 2 trees_oil on canvas_146×112㎝_2012

--- a/_posts/artworks/2012/2012-01-01-beach.md
+++ b/_posts/artworks/2012/2012-01-01-beach.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2012-2014"
+categories: "2014-2012"
 author: Jihoon Ha
 title: beach
 caption: beach_oil on canvas_150×150㎝_2012

--- a/_posts/artworks/2012/2012-01-01-blue-forest.md
+++ b/_posts/artworks/2012/2012-01-01-blue-forest.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2012-2014"
+categories: "2014-2012"
 author: Jihoon Ha
 title: blue forest
 caption: blue forest_acrylic,oil on canvas_227×182㎝_2012

--- a/_posts/artworks/2012/2012-01-01-es-trenc.md
+++ b/_posts/artworks/2012/2012-01-01-es-trenc.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2012-2014"
+categories: "2014-2012"
 author: Jihoon Ha
 title: es trenc
 caption: es trenc_acrylic,oil on canvas_132×162㎝_2012

--- a/_posts/artworks/2012/2012-01-01-forest.md
+++ b/_posts/artworks/2012/2012-01-01-forest.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2012-2014"
+categories: "2014-2012"
 author: Jihoon Ha
 title: forest
 caption: forest_oil on canvas_119×91㎝_2012

--- a/_posts/artworks/2012/2012-01-01-individual-landscape.md
+++ b/_posts/artworks/2012/2012-01-01-individual-landscape.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2012-2014"
+categories: "2014-2012"
 author: Jihoon Ha
 title: individual landscape
 caption: individual landscape_oil on canvas_70×70㎝_2012

--- a/_posts/artworks/2014/2014-01-01-botanical-garden.md
+++ b/_posts/artworks/2014/2014-01-01-botanical-garden.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2012-2014"
+categories: "2014-2012"
 author: Jihoon Ha
 title: botanical garden
 caption: botanical garden_oil on canvas_131×162㎝_2014

--- a/_posts/artworks/2014/2014-01-01-coast-1.md
+++ b/_posts/artworks/2014/2014-01-01-coast-1.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2012-2014"
+categories: "2014-2012"
 author: Jihoon Ha
 title: "coast #1"
 caption: "coast #1_oil on canvas_53×65㎝_2014"

--- a/_posts/artworks/2014/2014-01-01-coast-2.md
+++ b/_posts/artworks/2014/2014-01-01-coast-2.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2012-2014"
+categories: "2014-2012"
 author: Jihoon Ha
 title: "coast #2"
 caption: "coast #2_oil on canvas_38×46㎝_2014"

--- a/_posts/artworks/2014/2014-01-01-coast-3.md
+++ b/_posts/artworks/2014/2014-01-01-coast-3.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2012-2014"
+categories: "2014-2012"
 author: Jihoon Ha
 title: "coast #3"
 caption: "coast #3_oil on canvas_73×73㎝_2014"

--- a/_posts/artworks/2014/2014-01-01-coast-4.md
+++ b/_posts/artworks/2014/2014-01-01-coast-4.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2012-2014"
+categories: "2014-2012"
 author: Jihoon Ha
 title: "coast #4"
 caption: "coast #4_oil on canvas_32×41㎝_2014"

--- a/_posts/artworks/2014/2014-01-01-coast-5.md
+++ b/_posts/artworks/2014/2014-01-01-coast-5.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2012-2014"
+categories: "2014-2012"
 author: Jihoon Ha
 title: "coast #5"
 caption: "coast #5_oil on canvas_65×53㎝_2014"

--- a/_posts/artworks/2014/2014-01-01-mountain-in-island-1.md
+++ b/_posts/artworks/2014/2014-01-01-mountain-in-island-1.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2012-2014"
+categories: "2014-2012"
 author: Jihoon Ha
 title: "mountain in island #1"
 caption: "mountain in island #1_oil on canvas_70×70㎝_2014"

--- a/_posts/artworks/2014/2014-01-01-mountain-in-island-2.md
+++ b/_posts/artworks/2014/2014-01-01-mountain-in-island-2.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2012-2014"
+categories: "2014-2012"
 author: Jihoon Ha
 title: "mountain in island #2"
 caption: "mountain in island #2_oil on canvas_70×70㎝_2014"

--- a/_posts/artworks/2014/2014-01-01-mountain-in-island-4.md
+++ b/_posts/artworks/2014/2014-01-01-mountain-in-island-4.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2012-2014"
+categories: "2014-2012"
 author: Jihoon Ha
 title: "mountain in island #4"
 caption: "mountain in island #4_oil on canvas_70×70㎝_2014"

--- a/_posts/artworks/2014/2014-01-01-mountain-in-island-5.md
+++ b/_posts/artworks/2014/2014-01-01-mountain-in-island-5.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2012-2014"
+categories: "2014-2012"
 author: Jihoon Ha
 title: "mountain in island #5"
 caption: "mountain in island #5_oil on canvas_32×41㎝_2014"

--- a/_posts/artworks/2014/2014-01-01-mountain-in-island-6.md
+++ b/_posts/artworks/2014/2014-01-01-mountain-in-island-6.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2012-2014"
+categories: "2014-2012"
 author: Jihoon Ha
 title: "mountain in island #6"
 caption: "mountain in island #6_oil on canvas_32×41㎝_2014"

--- a/_posts/artworks/2014/2014-01-01-nightscape.md
+++ b/_posts/artworks/2014/2014-01-01-nightscape.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2012-2014"
+categories: "2014-2012"
 author: Jihoon Ha
 title: nightscape
 caption: nightscape_oil on canvas_38×46㎝_2014

--- a/_posts/artworks/2014/2014-01-01-promenade.md
+++ b/_posts/artworks/2014/2014-01-01-promenade.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2012-2014"
+categories: "2014-2012"
 author: Jihoon Ha
 title: promenade
 caption: promenade_oil on canvas_117×91㎝_2014

--- a/_posts/artworks/2014/2014-01-01-red-cloud.md
+++ b/_posts/artworks/2014/2014-01-01-red-cloud.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2012-2014"
+categories: "2014-2012"
 author: Jihoon Ha
 title: red cloud
 caption: red cloud_oil on canvas_32×32㎝_2014

--- a/_posts/artworks/2014/2014-01-01-red-forest.md
+++ b/_posts/artworks/2014/2014-01-01-red-forest.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2012-2014"
+categories: "2014-2012"
 author: Jihoon Ha
 title: red forest
 caption: red forest_oil on canvas_112×162㎝_2014

--- a/_posts/artworks/2014/2014-01-01-rocks.md
+++ b/_posts/artworks/2014/2014-01-01-rocks.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2012-2014"
+categories: "2014-2012"
 author: Jihoon Ha
 title: rocks
 caption: rocks_oil on canvas_50×90㎝_2014

--- a/_posts/artworks/2014/2014-01-01-the-big-isle.md
+++ b/_posts/artworks/2014/2014-01-01-the-big-isle.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2012-2014"
+categories: "2014-2012"
 author: Jihoon Ha
 title: the big isle
 caption: the big isle_oil on canvas_131×162㎝_2014

--- a/_posts/artworks/2014/2014-01-01-the-isle.md
+++ b/_posts/artworks/2014/2014-01-01-the-isle.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2012-2014"
+categories: "2014-2012"
 author: Jihoon Ha
 title: the isle
 caption: the isle_oil on canvas_70×70㎝_2014

--- a/_posts/artworks/2015/2015-01-01-landscape-figure.md
+++ b/_posts/artworks/2015/2015-01-01-landscape-figure.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2015-2016"
+categories: "2016-2015"
 author: Jihoon Ha
 title: landscape figure
 caption: landscape figure_oil on canvas_150×105㎝_2015

--- a/_posts/artworks/2015/2015-01-01-statue.md
+++ b/_posts/artworks/2015/2015-01-01-statue.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2015-2016"
+categories: "2016-2015"
 author: Jihoon Ha
 title: statue
 caption: statue_oil on canvas_117×91㎝_2015

--- a/_posts/artworks/2015/2015-01-01-terrace-forest.md
+++ b/_posts/artworks/2015/2015-01-01-terrace-forest.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2015-2016"
+categories: "2016-2015"
 author: Jihoon Ha
 title: terrace forest
 caption: terrace forest_oil on canvas_150×105㎝_2015

--- a/_posts/artworks/2015/2015-01-01-wet-forest.md
+++ b/_posts/artworks/2015/2015-01-01-wet-forest.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2015-2016"
+categories: "2016-2015"
 author: Jihoon Ha
 title: wet forest
 caption: wet forest_oil on canvas_91×117㎝_2015

--- a/_posts/artworks/2016/2016-01-01-canyon-statue.md
+++ b/_posts/artworks/2016/2016-01-01-canyon-statue.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2015-2016"
+categories: "2016-2015"
 author: Jihoon Ha
 title: canyon statue
 caption: canyon statue_acrylic,oil on canvas_210×600㎝_2016

--- a/_posts/artworks/2016/2016-01-01-classical-landscape-1.md
+++ b/_posts/artworks/2016/2016-01-01-classical-landscape-1.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2015-2016"
+categories: "2016-2015"
 author: Jihoon Ha
 title: "classical landscape #1"
 caption: "classical landscape #1_oil on canvas_46×53㎝_2016"

--- a/_posts/artworks/2016/2016-01-01-classical-landscape-10.md
+++ b/_posts/artworks/2016/2016-01-01-classical-landscape-10.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2015-2016"
+categories: "2016-2015"
 author: Jihoon Ha
 title: "classical landscape #10"
 caption: "classical landscape #10_oil on canvas_46×53㎝_2016"

--- a/_posts/artworks/2016/2016-01-01-classical-landscape-13.md
+++ b/_posts/artworks/2016/2016-01-01-classical-landscape-13.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2015-2016"
+categories: "2016-2015"
 author: Jihoon Ha
 title: "classical landscape #13"
 caption: "classical landscape #13_oil on canvas_46×53㎝_2016"

--- a/_posts/artworks/2016/2016-01-01-classical-landscape-14.md
+++ b/_posts/artworks/2016/2016-01-01-classical-landscape-14.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2015-2016"
+categories: "2016-2015"
 author: Jihoon Ha
 title: "classical landscape #14"
 caption: "classical landscape #14_oil on canvas_46×53㎝_2016"

--- a/_posts/artworks/2016/2016-01-01-classical-landscape-15.md
+++ b/_posts/artworks/2016/2016-01-01-classical-landscape-15.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2015-2016"
+categories: "2016-2015"
 author: Jihoon Ha
 title: "classical landscape #15"
 caption: "classical landscape #15_oil on canvas_46×53㎝_2016"

--- a/_posts/artworks/2016/2016-01-01-classical-landscape-16.md
+++ b/_posts/artworks/2016/2016-01-01-classical-landscape-16.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2015-2016"
+categories: "2016-2015"
 author: Jihoon Ha
 title: "classical landscape #16"
 caption: "classical landscape #16_oil on canvas_46×53㎝_2016"

--- a/_posts/artworks/2016/2016-01-01-classical-landscape-17.md
+++ b/_posts/artworks/2016/2016-01-01-classical-landscape-17.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2015-2016"
+categories: "2016-2015"
 author: Jihoon Ha
 title: "classical landscape #17"
 caption: "classical landscape #17_oil on canvas_46×53㎝_2016"

--- a/_posts/artworks/2016/2016-01-01-classical-landscape-18.md
+++ b/_posts/artworks/2016/2016-01-01-classical-landscape-18.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2015-2016"
+categories: "2016-2015"
 author: Jihoon Ha
 title: "classical landscape #18"
 caption: "classical landscape #18_oil on canvas_46×53㎝_2016"

--- a/_posts/artworks/2016/2016-01-01-classical-landscape-2.md
+++ b/_posts/artworks/2016/2016-01-01-classical-landscape-2.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2015-2016"
+categories: "2016-2015"
 author: Jihoon Ha
 title: "classical landscape #2"
 caption: "classical landscape #2_oil on canvas_46×53㎝_2016"

--- a/_posts/artworks/2016/2016-01-01-classical-landscape-20.md
+++ b/_posts/artworks/2016/2016-01-01-classical-landscape-20.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2015-2016"
+categories: "2016-2015"
 author: Jihoon Ha
 title: "classical landscape #20"
 caption: "classical landscape #20_oil on canvas_46×53㎝_2016"

--- a/_posts/artworks/2016/2016-01-01-classical-landscape-3.md
+++ b/_posts/artworks/2016/2016-01-01-classical-landscape-3.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2015-2016"
+categories: "2016-2015"
 author: Jihoon Ha
 title: "classical landscape #3"
 caption: "classical landscape #3_oil on canvas_46×53㎝_2016"

--- a/_posts/artworks/2016/2016-01-01-classical-landscape-4.md
+++ b/_posts/artworks/2016/2016-01-01-classical-landscape-4.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2015-2016"
+categories: "2016-2015"
 author: Jihoon Ha
 title: "classical landscape #4"
 caption: "classical landscape #4_oil on canvas_46×53㎝_2016"

--- a/_posts/artworks/2016/2016-01-01-classical-landscape-5.md
+++ b/_posts/artworks/2016/2016-01-01-classical-landscape-5.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2015-2016"
+categories: "2016-2015"
 author: Jihoon Ha
 title: "classical landscape #5"
 caption: "classical landscape #5_oil on canvas_46×53㎝_2016"

--- a/_posts/artworks/2016/2016-01-01-classical-landscape-6.md
+++ b/_posts/artworks/2016/2016-01-01-classical-landscape-6.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2015-2016"
+categories: "2016-2015"
 author: Jihoon Ha
 title: "classical landscape #6"
 caption: "classical landscape #6_oil on canvas_46×53㎝_2016"

--- a/_posts/artworks/2016/2016-01-01-classical-landscape-7.md
+++ b/_posts/artworks/2016/2016-01-01-classical-landscape-7.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2015-2016"
+categories: "2016-2015"
 author: Jihoon Ha
 title: "classical landscape #7"
 caption: "classical landscape #7_oil on canvas_46×53㎝_2016"

--- a/_posts/artworks/2016/2016-01-01-classical-landscape-8.md
+++ b/_posts/artworks/2016/2016-01-01-classical-landscape-8.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2015-2016"
+categories: "2016-2015"
 author: Jihoon Ha
 title: "classical landscape #8"
 caption: "classical landscape #8_oil on canvas_46×53㎝_2016"

--- a/_posts/artworks/2016/2016-01-01-classical-landscape-9.md
+++ b/_posts/artworks/2016/2016-01-01-classical-landscape-9.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2015-2016"
+categories: "2016-2015"
 author: Jihoon Ha
 title: "classical landscape #9"
 caption: "classical landscape #9_oil on canvas_46×53㎝_2016"

--- a/_posts/artworks/2016/2016-01-01-gemstone-isle-1.md
+++ b/_posts/artworks/2016/2016-01-01-gemstone-isle-1.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2015-2016"
+categories: "2016-2015"
 author: Jihoon Ha
 title: "gemstone isle #1"
 caption: "gemstone isle #1_acrylic,oil on canvas_227×182㎝_2016"

--- a/_posts/artworks/2016/2016-01-01-gemstone-isle-2.md
+++ b/_posts/artworks/2016/2016-01-01-gemstone-isle-2.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2015-2016"
+categories: "2016-2015"
 author: Jihoon Ha
 title: "gemstone isle #2"
 caption: "gemstone isle #2_acrylic,oil on canvas_227x182cm_2016"

--- a/_posts/artworks/2016/2016-01-01-gemstone-isle-3.md
+++ b/_posts/artworks/2016/2016-01-01-gemstone-isle-3.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2015-2016"
+categories: "2016-2015"
 author: Jihoon Ha
 title: "gemstone isle #3"
 caption: "gemstone isle #3_acrylic,oil on canvas_70×70㎝_2016"

--- a/_posts/artworks/2016/2016-01-01-gemstone-isle-4.md
+++ b/_posts/artworks/2016/2016-01-01-gemstone-isle-4.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2015-2016"
+categories: "2016-2015"
 author: Jihoon Ha
 title: "gemstone isle #4"
 caption: "gemstone isle #4_acrylic,oil on canvas_70×70㎝_2016"

--- a/_posts/artworks/2016/2016-01-01-gemstone-isle-5.md
+++ b/_posts/artworks/2016/2016-01-01-gemstone-isle-5.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2015-2016"
+categories: "2016-2015"
 author: Jihoon Ha
 title: "gemstone isle #5"
 caption: "gemstone isle #5_acrylic,oil on canvas_33×41㎝_2016"

--- a/_posts/artworks/2016/2016-01-01-gemstone-isle-6.md
+++ b/_posts/artworks/2016/2016-01-01-gemstone-isle-6.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2015-2016"
+categories: "2016-2015"
 author: Jihoon Ha
 title: "gemstone isle #6"
 caption: "gemstone isle #6_acrylic,oil on canvas_70×70㎝_2016"

--- a/_posts/artworks/2016/2016-01-01-gemstone-isle-7.md
+++ b/_posts/artworks/2016/2016-01-01-gemstone-isle-7.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2015-2016"
+categories: "2016-2015"
 author: Jihoon Ha
 title: "gemstone isle #7"
 caption: "gemstone isle #7_acrylic,oil on canvas_70×70㎝_2016"

--- a/_posts/artworks/2016/2016-01-01-islandfigure.md
+++ b/_posts/artworks/2016/2016-01-01-islandfigure.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2015-2016"
+categories: "2016-2015"
 author: Jihoon Ha
 title: island-figure
 caption: island-figure_oil on canvas_150×105㎝_2016

--- a/_posts/artworks/2016/2016-01-01-monumental-mountain-1.md
+++ b/_posts/artworks/2016/2016-01-01-monumental-mountain-1.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2015-2016"
+categories: "2016-2015"
 author: Jihoon Ha
 title: "monumental mountain #1"
 caption: "monumental mountain #1_acrylic,oil on canvas_205×205㎝_2016"

--- a/_posts/artworks/2016/2016-01-01-monumental-mountain-2.md
+++ b/_posts/artworks/2016/2016-01-01-monumental-mountain-2.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2015-2016"
+categories: "2016-2015"
 author: Jihoon Ha
 title: "monumental mountain #2"
 caption: "monumental mountain #2_acrylic,oil on canvas_205×205㎝_2016"

--- a/_posts/artworks/2016/2016-01-01-monumental-mountain-3.md
+++ b/_posts/artworks/2016/2016-01-01-monumental-mountain-3.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2015-2016"
+categories: "2016-2015"
 author: Jihoon Ha
 title: "monumental mountain #3"
 caption: "monumental mountain #3_acrylic,oil on canvas_205×205㎝_2016"

--- a/_posts/artworks/2016/2016-01-01-monumental-mountain-4.md
+++ b/_posts/artworks/2016/2016-01-01-monumental-mountain-4.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2015-2016"
+categories: "2016-2015"
 author: Jihoon Ha
 title: "monumental mountain #4"
 caption: "monumental mountain #4_acrylic,oil on canvas_205×205㎝_2016"

--- a/_posts/artworks/2019/2019-04-04-gemstone-isle-38.md
+++ b/_posts/artworks/2019/2019-04-04-gemstone-isle-38.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2019-2020"
+categories: "2020-2019"
 author: Jihoon Ha
 title: "gemstone isle #38"
 caption: "gemstone isle #38_acrylic oil on canvas_105×150㎝_2019"

--- a/_posts/artworks/2019/2019-04-04-gemstone-isle-39.md
+++ b/_posts/artworks/2019/2019-04-04-gemstone-isle-39.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2019-2020"
+categories: "2020-2019"
 author: Jihoon Ha
 title: "gemstone isle #39"
 caption: "gemstone isle #39_acrylic oil on canvas_105×150㎝_2019"

--- a/_posts/artworks/2019/2019-04-04-gemstone-isle-40.md
+++ b/_posts/artworks/2019/2019-04-04-gemstone-isle-40.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2019-2020"
+categories: "2020-2019"
 author: Jihoon Ha
 title: "gemstone isle #40"
 caption: "gemstone isle #40_acrylic oil on canvas_105×150㎝_2019"

--- a/_posts/artworks/2019/2019-04-04-gemstone-isle-41.md
+++ b/_posts/artworks/2019/2019-04-04-gemstone-isle-41.md
@@ -1,6 +1,6 @@
 ---
 layout: artwork
-categories: "2019-2020"
+categories: "2020-2019"
 author: Jihoon Ha
 title: "gemstone isle #41"
 caption: "gemstone isle #41_acrylic oil on canvas_105×150㎝_2019"

--- a/_posts/artworks/2019/2020-06-30-gemstone-isle-27.md
+++ b/_posts/artworks/2019/2020-06-30-gemstone-isle-27.md
@@ -1,6 +1,6 @@
 ---
 layout: "artwork"
-categories: "2019-2020"
+categories: "2020-2019"
 author: "Jihoon Ha"
 title: "gemstone isle #27"
 caption: "gemstone isle #27_acrylic_oil on canvas_150×105㎝_2019"

--- a/_posts/artworks/2019/2020-06-30-gemstone-isle-43-Kyoto.md
+++ b/_posts/artworks/2019/2020-06-30-gemstone-isle-43-Kyoto.md
@@ -1,6 +1,6 @@
 ---
 layout: "artwork"
-categories: "2019-2020"
+categories: "2020-2019"
 author: "Jihoon Ha"
 title: "gemstone isle #43-Kyoto"
 caption: "gemstone isle #43-Kyoto_acrylic oil on canvas_227×182㎝_2019"

--- a/_posts/artworks/2019/2020-06-30-gemstone-isle-48.md
+++ b/_posts/artworks/2019/2020-06-30-gemstone-isle-48.md
@@ -1,6 +1,6 @@
 ---
 layout: "artwork"
-categories: "2019-2020"
+categories: "2020-2019"
 author: "Jihoon Ha"
 title: "gemstone isle #48"
 caption: "gemstone isle #48_acrylic_oil on panel 91×73㎝_2019"

--- a/_posts/artworks/2019/2020-06-30-structure-of-flower-2.md
+++ b/_posts/artworks/2019/2020-06-30-structure-of-flower-2.md
@@ -1,6 +1,6 @@
 ---
 layout: "artwork"
-categories: "2019-2020"
+categories: "2020-2019"
 author: "Jihoon Ha"
 title: "structure of flower #2"
 caption: "structure of flower #2_oil on panel 22×16㎝_2019"

--- a/_posts/artworks/2019/2020-06-30-structure-of-flower-3.md
+++ b/_posts/artworks/2019/2020-06-30-structure-of-flower-3.md
@@ -1,6 +1,6 @@
 ---
 layout: "artwork"
-categories: "2019-2020"
+categories: "2020-2019"
 author: "Jihoon Ha"
 title: "structure of flower #3"
 caption: "structure of flower #3_oil on canvas_33×24㎝_2019"

--- a/_posts/artworks/2019/2020-06-30-structure-of-flower-4.md
+++ b/_posts/artworks/2019/2020-06-30-structure-of-flower-4.md
@@ -1,6 +1,6 @@
 ---
 layout: "artwork"
-categories: "2019-2020"
+categories: "2020-2019"
 author: "Jihoon Ha"
 title: "structure of flower #4"
 caption: "structure of flower #4_oil on canvas_33×24㎝_2019"

--- a/_posts/artworks/2019/2020-06-30-structure-of-landscape-1.md
+++ b/_posts/artworks/2019/2020-06-30-structure-of-landscape-1.md
@@ -1,6 +1,6 @@
 ---
 layout: "artwork"
-categories: "2019-2020"
+categories: "2020-2019"
 author: "Jihoon Ha"
 title: "structure of landscape #1(corsica)"
 caption: "structure of landscape #1(corsica)_acrylic oil on canvas_182×227㎝_2019"

--- a/_posts/artworks/2019/2020-06-30-structure-of-landscape-2.md
+++ b/_posts/artworks/2019/2020-06-30-structure-of-landscape-2.md
@@ -1,6 +1,6 @@
 ---
 layout: "artwork"
-categories: "2019-2020"
+categories: "2020-2019"
 author: "Jihoon Ha"
 title: "structure of landscape #2"
 caption: "structure of landscape #2_oil on canvas_33×24㎝_2019"

--- a/_posts/artworks/2019/2020-06-30-structure-of-landscape-3.md
+++ b/_posts/artworks/2019/2020-06-30-structure-of-landscape-3.md
@@ -1,6 +1,6 @@
 ---
 layout: "artwork"
-categories: "2019-2020"
+categories: "2020-2019"
 author: "Jihoon Ha"
 title: "structure of landscape #3(Marseille)"
 caption: "structure of landscape #3(Marseille)_acrylic oil on canvas_105×150㎝_2019"

--- a/_posts/artworks/2019/2020-06-30-structure-of-landscape-4.md
+++ b/_posts/artworks/2019/2020-06-30-structure-of-landscape-4.md
@@ -1,6 +1,6 @@
 ---
 layout: "artwork"
-categories: "2019-2020"
+categories: "2020-2019"
 author: "Jihoon Ha"
 title: "structure of landscape #4(Marseille)"
 caption: "structure of landscape #4(Marseille)_acrylic oil on canvas_150×105㎝_2019"

--- a/_posts/artworks/2019/2020-06-30-structure-of-winter-1.md
+++ b/_posts/artworks/2019/2020-06-30-structure-of-winter-1.md
@@ -1,6 +1,6 @@
 ---
 layout: "artwork"
-categories: "2019-2020"
+categories: "2020-2019"
 author: "Jihoon Ha"
 title: "structure of winter #1"
 caption: "structure of winter #1_oil on panel 22×16㎝_2019"

--- a/_posts/artworks/2019/2020-06-30-structure-of-winter-2.md
+++ b/_posts/artworks/2019/2020-06-30-structure-of-winter-2.md
@@ -1,6 +1,6 @@
 ---
 layout: "artwork"
-categories: "2019-2020"
+categories: "2020-2019"
 author: "Jihoon Ha"
 title: "structure of winter #2"
 caption: "structure of winter #2_oil on canvas_33×24㎝_2019"

--- a/_posts/artworks/2019/2020-06-30-structure-of-winter-3.md
+++ b/_posts/artworks/2019/2020-06-30-structure-of-winter-3.md
@@ -1,6 +1,6 @@
 ---
 layout: "artwork"
-categories: "2019-2020"
+categories: "2020-2019"
 author: "Jihoon Ha"
 title: "structure of winter #3"
 caption: "structure of winter #3_oil on canvas_33×24㎝_2019"

--- a/_posts/artworks/2020/2020-06-30-landscape-structure-10.md
+++ b/_posts/artworks/2020/2020-06-30-landscape-structure-10.md
@@ -1,6 +1,6 @@
 ---
 layout: "artwork"
-categories: "2019-2020"
+categories: "2020-2019"
 author: "Jihoon Ha"
 title: "landscape-structure #10"
 caption: "landscape-structure #10_oil on canvas_33×24㎝_2020"

--- a/_posts/artworks/2020/2020-06-30-landscape-structure-11.md
+++ b/_posts/artworks/2020/2020-06-30-landscape-structure-11.md
@@ -1,6 +1,6 @@
 ---
 layout: "artwork"
-categories: "2019-2020"
+categories: "2020-2019"
 author: "Jihoon Ha"
 title: "landscape-structure #11"
 caption: "landscape-structure #11_oil on canvas_33×24㎝_2020"

--- a/_posts/artworks/2020/2020-06-30-landscape-structure-12.md
+++ b/_posts/artworks/2020/2020-06-30-landscape-structure-12.md
@@ -1,6 +1,6 @@
 ---
 layout: "artwork"
-categories: "2019-2020"
+categories: "2020-2019"
 author: "Jihoon Ha"
 title: "landscape-structure #12"
 caption: "landscape-structure #12_oil on canvas_33×24㎝_2020"

--- a/_posts/artworks/2020/2020-06-30-landscape-structure-13.md
+++ b/_posts/artworks/2020/2020-06-30-landscape-structure-13.md
@@ -1,6 +1,6 @@
 ---
 layout: "artwork"
-categories: "2019-2020"
+categories: "2020-2019"
 author: "Jihoon Ha"
 title: "landscape-structure #13"
 caption: "landscape-structure #13_oil on canvas_33×24㎝_2020"

--- a/_posts/artworks/2020/2020-06-30-landscape-structure-14.md
+++ b/_posts/artworks/2020/2020-06-30-landscape-structure-14.md
@@ -1,6 +1,6 @@
 ---
 layout: "artwork"
-categories: "2019-2020"
+categories: "2020-2019"
 author: "Jihoon Ha"
 title: "landscape-structure #14"
 caption: "landscape-structure #14_oil on canvas_33×24㎝_2020"

--- a/_posts/artworks/2020/2020-06-30-landscape-structure-15.md
+++ b/_posts/artworks/2020/2020-06-30-landscape-structure-15.md
@@ -1,6 +1,6 @@
 ---
 layout: "artwork"
-categories: "2019-2020"
+categories: "2020-2019"
 author: "Jihoon Ha"
 title: "landscape-structure #15"
 caption: "landscape-structure #15_oil on canvas_33×24㎝_2020"

--- a/_posts/artworks/2020/2020-06-30-landscape-structure-16.md
+++ b/_posts/artworks/2020/2020-06-30-landscape-structure-16.md
@@ -1,6 +1,6 @@
 ---
 layout: "artwork"
-categories: "2019-2020"
+categories: "2020-2019"
 author: "Jihoon Ha"
 title: "landscape-structure #16"
 caption: "landscape-structure #16_oil on canvas_33×24㎝_2020"

--- a/_posts/artworks/2020/2020-06-30-landscape-structure-17.md
+++ b/_posts/artworks/2020/2020-06-30-landscape-structure-17.md
@@ -1,6 +1,6 @@
 ---
 layout: "artwork"
-categories: "2019-2020"
+categories: "2020-2019"
 author: "Jihoon Ha"
 title: "landscape-structure #17"
 caption: "landscape-structure #17_oil on canvas_33×24㎝_2020"

--- a/_posts/artworks/2020/2020-06-30-landscape-structure-18.md
+++ b/_posts/artworks/2020/2020-06-30-landscape-structure-18.md
@@ -1,6 +1,6 @@
 ---
 layout: "artwork"
-categories: "2019-2020"
+categories: "2020-2019"
 author: "Jihoon Ha"
 title: "landscape-structure #18"
 caption: "landscape-structure #18_oil on canvas_33×24㎝_2020"

--- a/_posts/artworks/2020/2020-06-30-landscape-structure-19.md
+++ b/_posts/artworks/2020/2020-06-30-landscape-structure-19.md
@@ -1,6 +1,6 @@
 ---
 layout: "artwork"
-categories: "2019-2020"
+categories: "2020-2019"
 author: "Jihoon Ha"
 title: "landscape-structure #19"
 caption: "landscape-structure #19_oil on canvas_33×24㎝_2020"

--- a/_posts/artworks/2020/2020-06-30-landscape-structure-20.md
+++ b/_posts/artworks/2020/2020-06-30-landscape-structure-20.md
@@ -1,6 +1,6 @@
 ---
 layout: "artwork"
-categories: "2019-2020"
+categories: "2020-2019"
 author: "Jihoon Ha"
 title: "landscape-structure #20"
 caption: "landscape-structure #20_oil on canvas_33×24㎝_2020"

--- a/_posts/artworks/2020/2020-06-30-landscape-structure-21.md
+++ b/_posts/artworks/2020/2020-06-30-landscape-structure-21.md
@@ -1,6 +1,6 @@
 ---
 layout: "artwork"
-categories: "2019-2020"
+categories: "2020-2019"
 author: "Jihoon Ha"
 title: "landscape-structure #21"
 caption: "landscape-structure #21_oil on canvas_33×24㎝_2020"

--- a/_posts/artworks/2020/2020-06-30-landscape-structure-22.md
+++ b/_posts/artworks/2020/2020-06-30-landscape-structure-22.md
@@ -1,6 +1,6 @@
 ---
 layout: "artwork"
-categories: "2019-2020"
+categories: "2020-2019"
 author: "Jihoon Ha"
 title: "landscape-structure #22"
 caption: "landscape-structure #22_oil on canvas_33×24㎝_2020"

--- a/_posts/artworks/2020/2020-06-30-landscape-structure-23.md
+++ b/_posts/artworks/2020/2020-06-30-landscape-structure-23.md
@@ -1,6 +1,6 @@
 ---
 layout: "artwork"
-categories: "2019-2020"
+categories: "2020-2019"
 author: "Jihoon Ha"
 title: "landscape-structure #23(Aix-en-Provence)"
 caption: "landscape-structure #23(Aix-en-Provence)_acrylic oil on canvas_91×117㎝_2020"

--- a/_posts/artworks/2020/2020-06-30-landscape-structure-5.md
+++ b/_posts/artworks/2020/2020-06-30-landscape-structure-5.md
@@ -1,6 +1,6 @@
 ---
 layout: "artwork"
-categories: "2019-2020"
+categories: "2020-2019"
 author: "Jihoon Ha"
 title: "structure of flower #5"
 caption: "structure of flower #5_oil on canvas_33×24㎝_2020"

--- a/_posts/artworks/2020/2020-06-30-landscape-structure-6.md
+++ b/_posts/artworks/2020/2020-06-30-landscape-structure-6.md
@@ -1,6 +1,6 @@
 ---
 layout: "artwork"
-categories: "2019-2020"
+categories: "2020-2019"
 author: "Jihoon Ha"
 title: "landscape-structure #6"
 caption: "landscape-structure #6_acrylic oil on canvas_150×105㎝_2020"

--- a/_posts/artworks/2020/2020-06-30-landscape-structure-7.md
+++ b/_posts/artworks/2020/2020-06-30-landscape-structure-7.md
@@ -1,6 +1,6 @@
 ---
 layout: "artwork"
-categories: "2019-2020"
+categories: "2020-2019"
 author: "Jihoon Ha"
 title: "landscape-structure #7(corsica)"
 caption: "landscape-structure #7(corsica)_acrylic oil on canvas_117×91㎝_2020"

--- a/_posts/artworks/2020/2020-06-30-landscape-structure-8.md
+++ b/_posts/artworks/2020/2020-06-30-landscape-structure-8.md
@@ -1,6 +1,6 @@
 ---
 layout: "artwork"
-categories: "2019-2020"
+categories: "2020-2019"
 author: "Jihoon Ha"
 title: "landscape-structure #8(corsica)"
 caption: "landscape-structure #8(corsica)_acrylic oil on canvas_117×91㎝_2020"

--- a/_posts/artworks/2020/2020-06-30-landscape-structure-9.md
+++ b/_posts/artworks/2020/2020-06-30-landscape-structure-9.md
@@ -1,6 +1,6 @@
 ---
 layout: "artwork"
-categories: "2019-2020"
+categories: "2020-2019"
 author: "Jihoon Ha"
 title: "landscape-structure #9(Aix-en-Provence)"
 caption: "landscape-structure #9(Aix-en-Provence)_acrylic oil on canvas_117×91㎝_2020"

--- a/_posts/artworks/2020/2020-06-30-structure-of-flower-5.md
+++ b/_posts/artworks/2020/2020-06-30-structure-of-flower-5.md
@@ -1,6 +1,6 @@
 ---
 layout: "artwork"
-categories: "2019-2020"
+categories: "2020-2019"
 author: "Jihoon Ha"
 title: "structure of flower #5"
 caption: "structure of flower #5_oil on canvas_33×24㎝_2020"

--- a/artwork2007-2009.html
+++ b/artwork2007-2009.html
@@ -1,11 +1,11 @@
 ---
 layout: artworks
-title: ARTWORK - 2007-2009
-item: "2007-2009"
-permalink: /artwork/2007-2009
+title: ARTWORK - 2009-2007
+item: "2009-2007"
+permalink: /artwork/2009-2007
 navItemTitle: artwork
 og:
-  title: ARTWORK - 2007-2009
+  title: ARTWORK - 2009-2007
   description: Jihoon Ha's artworks
   image: ~
   card: summary_large_image

--- a/artwork2010-2011.html
+++ b/artwork2010-2011.html
@@ -1,11 +1,11 @@
 ---
 layout: artworks
-title: ARTWORK - 2010-2011
-item: "2010-2011"
-permalink: /artwork/2010-2011
+title: ARTWORK - 2011-2010
+item: "2011-2010"
+permalink: /artwork/2011-2010
 navItemTitle: artwork
 og:
-  title: ARTWORK - 2010-2011
+  title: ARTWORK - 2011-2010
   description: Jihoon Ha's artworks
   image: ~
   card: summary_large_image

--- a/artwork2012-2014.html
+++ b/artwork2012-2014.html
@@ -1,11 +1,11 @@
 ---
 layout: artworks
-title: ARTWORK - 2012-2014
-item: "2012-2014"
-permalink: /artwork/2012-2014
+title: ARTWORK - 2014-2012
+item: "2014-2012"
+permalink: /artwork/2014-2012
 navItemTitle: artwork
 og:
-  title: ARTWORK - 2012-2014
+  title: ARTWORK - 2014-2012
   description: Jihoon Ha's artworks
   image: ~
   card: summary_large_image

--- a/artwork2015-2016.html
+++ b/artwork2015-2016.html
@@ -1,11 +1,11 @@
 ---
 layout: artworks
-title: ARTWORK - 2015-2016
-item: "2015-2016"
-permalink: /artwork/2015-2016
+title: ARTWORK - 2016-2015
+item: "2016-2015"
+permalink: /artwork/2016-2015
 navItemTitle: artwork
 og:
-  title: ARTWORK - 2015-2016
+  title: ARTWORK - 2016-2015
   description: Jihoon Ha's artworks
   image: ~
   card: summary_large_image

--- a/artwork2019-2020.html
+++ b/artwork2019-2020.html
@@ -1,11 +1,11 @@
 ---
 layout: artworks
-title: ARTWORK - 2019-2020
-item: "2019-2020"
-permalink: /artwork/2019-2020
+title: ARTWORK - 2020-2019
+item: "2020-2019"
+permalink: /artwork/2020-2019
 navItemTitle: artwork
 og:
-  title: ARTWORK - 2019-2020
+  title: ARTWORK - 2020-2019
   description: Jihoon Ha's artworks
   image: ~
   card: summary_large_image

--- a/assets/custom.css
+++ b/assets/custom.css
@@ -60,6 +60,10 @@ li, p, a, span, h1, h2, h3, h4, h5, h6 {
 .global-wrapper .site-header .navigation .nav-main > li:hover .nav-sub {
   display: flex;
 }
+.global-wrapper .site-header .navigation .nav-main > li:hover ~ .active .nav-sub {
+  display: none;
+}
+
 .global-wrapper .site-header .navigation .nav-main > li .nav-sub > li {
   float: none;
 }

--- a/cv-ko.md
+++ b/cv-ko.md
@@ -1,7 +1,7 @@
 ---
-layout: cv
+layout: cv-ko
 title: Jihoon Ha(하지훈, 河芝勳)
-permalink: /cv
+permalink: /cv-ko
 navItemTitle: cv
 og:
   title: CV - Jihoon Ha


### PR DESCRIPTION
- 예: `2019-2020`을 `2020-2019`로 변경
- 메인메뉴에 서브메뉴가 두 개 이상 있을 때 겹치지 않도록 수정